### PR TITLE
Update test_opencl.cpp

### DIFF
--- a/src/test_opencl.cpp
+++ b/src/test_opencl.cpp
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
 		std::cerr<<"Choosing device "<<selectedDevice<<"\n";
 		cl::Device device=devices.at(selectedDevice);
 		
-		cl::Context context(device);
+		cl::Context context(devices);
 
 		std::string kernelSource="__kernel void Add(__global float *x){ x[get_global_id(0)] += 0.125f; }\n";
 		


### PR DESCRIPTION
Typo on line 83, I believe it should be devices otherwise it fails to compile.

Here was the error I got when compiling the original version.
src/test_opencl.cpp: In function ‘int main(int, char**)’:
src/test_opencl.cpp:83:29: error: no matching function for call to ‘cl::Context::Context(cl::Device&)’
   cl::Context context(device);
                             ^
src/test_opencl.cpp:83:29: note: candidates are:
In file included from src/test_opencl.cpp:22:0:
include/CL/cl.hpp:1466:5: note: cl::Context::Context(const cl::Context&)
     Context(const Context& context) : detail::Wrapper<cl_type>(context) { }
     ^
include/CL/cl.hpp:1466:5: note:   no known conversion for argument 1 from ‘cl::Device’ to ‘const cl::Context&’
include/CL/cl.hpp:1464:5: note: cl::Context::Context()
     Context() : detail::Wrapper<cl_type>() { }
     ^
include/CL/cl.hpp:1464:5: note:   candidate expects 0 arguments, 1 provided
include/CL/cl.hpp:1443:5: note: cl::Context::Context(cl_device_type, cl_context_properties*, void (*)(const char*, const void*, size_t, void*), void*, cl_int*)
     Context(
     ^
include/CL/cl.hpp:1443:5: note:   no known conversion for argument 1 from ‘cl::Device’ to ‘cl_device_type {aka long unsigned int}’
include/CL/cl.hpp:1420:5: note: cl::Context::Context(const std::vector<cl::Device>&, cl_context_properties*, void (*)(const char*, const void*, size_t, void*), void*, cl_int*)
     Context(
     ^
include/CL/cl.hpp:1420:5: note:   no known conversion for argument 1 from ‘cl::Device’ to ‘const std::vector<cl::Device>&’