### PR TITLE
Change stdout to binary mode when rendering bmp on Windows

### DIFF
--- a/src/heat.cpp
+++ b/src/heat.cpp
@@ -7,6 +7,11 @@
 #include <cstdio>
 #include <string>
 
+#if defined(WIN32) || defined(_WIN32)
+#include <io.h>
+#include <fcntl.h>
+#endif
+
 namespace hpce{
 	
 //! Create a square world with a standardised "slalom track"
@@ -273,6 +278,11 @@ void RenderWorld(const std::string &fileName, const world_t &world)
 		dst=fopen(fileName.c_str(), "wb");
 		if(dst==0)
 			throw std::runtime_error("RenderWorld : Couldn't open destination file.");
+	}else{
+#if defined(WIN32) || defined(_WIN32)
+		setmode(fileno(stdin), O_BINARY);
+		setmode(fileno(stdout), O_BINARY);
+#endif
 	}
 	try{
 		if(sizeof(file)!=fwrite(file, 1, sizeof(file), dst))


### PR DESCRIPTION
When I redirect the output from `render_world` to something else, e.g.
``render_world | bmptopnm | pnmtopng > $@``
The output image is distorted:
![](http://zhiyb.github.io/hpce-2016-cw3/bad.png)

I suspect this is due to how Windows handles `stdout`, so I changed the open mode of `stdout` to binary on Windows. And it works:
![](http://zhiyb.github.io/hpce-2016-cw3/good.png)