### PR TITLE
Change stdin and stdout to binary mode on Windows

### DIFF
--- a/src/heat.cpp
+++ b/src/heat.cpp
@@ -7,6 +7,11 @@
 #include <cstdio>
 #include <string>
 
+#if defined(WIN32) || defined(_WIN32)
+#include <io.h>
+#include <fcntl.h>
+#endif
+
 namespace hpce{
 	
 //! Create a square world with a standardised "slalom track"
@@ -273,6 +278,11 @@ void RenderWorld(const std::string &fileName, const world_t &world)
 		dst=fopen(fileName.c_str(), "wb");
 		if(dst==0)
 			throw std::runtime_error("RenderWorld : Couldn't open destination file.");
+	}else{
+#if defined(WIN32) || defined(_WIN32)
+		setmode(fileno(stdin), O_BINARY);
+		setmode(fileno(stdout), O_BINARY);
+#endif
 	}
 	try{
 		if(sizeof(file)!=fwrite(file, 1, sizeof(file), dst))

--- a/src/heat.cpp
+++ b/src/heat.cpp
@@ -1,3 +1,9 @@
+#if defined(WIN32) || defined(_WIN32)
+#define _POSIX_SOURCE
+#include <io.h>
+#include <fcntl.h>
+#endif
+
 #include "heat.hpp"
 
 #include <stdexcept>
@@ -6,11 +12,6 @@
 #include <memory>
 #include <cstdio>
 #include <string>
-
-#if defined(WIN32) || defined(_WIN32)
-#include <io.h>
-#include <fcntl.h>
-#endif
 
 namespace hpce{
 	
@@ -75,6 +76,10 @@ world_t MakeTestWorld(unsigned n, float alpha)
 //! Save the give world to a file
 void SaveWorld(std::ostream &dst, const world_t &world, bool binary)
 {	
+#if defined(WIN32) || defined(_WIN32)
+	setmode(fileno(stdin), O_BINARY);
+	setmode(fileno(stdout), O_BINARY);
+#endif
 	if(binary){
 		dst<<"HPCEHeatWorldV0Binary"<<std::endl;
 	}else{
@@ -133,6 +138,10 @@ world_t LoadWorld(std::istream &src)
 {
 	bool binary=false;
 	
+#if defined(WIN32) || defined(_WIN32)
+	setmode(fileno(stdin), O_BINARY);
+	setmode(fileno(stdout), O_BINARY);
+#endif
 	std::string header;
 	src>>header;
 	if(header=="HPCEHeatWorldV0"){


### PR DESCRIPTION
On my Windows platform, every output byte of `0x0a (\n)` will be prepended with `0x0d (\r)`, without binary mode applied.

Reference: #35 

Thanks @jeremych1000 for testing😃.